### PR TITLE
fix UnicodeDecodeError during installation when trying to read README.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import sys
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
-from pipetools import X
+from pipetools import xpartial, X
 import pipetools
 
 
@@ -25,7 +25,7 @@ setup(
     version=pipetools.__versionstr__,
     description=('A library that enables function composition similar to '
         'using Unix pipes.'),
-    long_description='README.rst' > open | X.read(),
+    long_description='README.rst' > xpartial(open, X, encoding="utf-8") | X.read(),
     author='Petr Pokorny',
     author_email='petr@innit.cz',
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import io
 import sys
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
@@ -25,7 +26,7 @@ setup(
     version=pipetools.__versionstr__,
     description=('A library that enables function composition similar to '
         'using Unix pipes.'),
-    long_description='README.rst' > xpartial(open, X, encoding="utf-8") | X.read(),
+    long_description='README.rst' > xpartial(io.open, X, encoding="utf-8") | X.read(),
     author='Petr Pokorny',
     author_email='petr@innit.cz',
     license='MIT',


### PR DESCRIPTION
# issue
I encounter an `UnicodeDecodeError` when trying to install pipetools on windows 7 (pip 10, python 3.6.5). Figure out that this is caused by file encoding issue when trying to open README.rst
sth. like 
```
UnicodeDecodeError: 'gbk' codec can't decode byte 0x80 in position 205: illegal multibyte sequence
```

# what this fix does
Use `io.open` for python 2/3 compatibility, set the encoding paramater of `io.open` to `utf-8` fixs the issue.