### PR TITLE
added reflected version of magic methods

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinx==1.7.4
-coverage-badge==1.0.1
+coverage-badge==1.1.0
 pytest==6.2.4
 pytest-cov==2.12.1

--- a/docs/source/xobject.rst
+++ b/docs/source/xobject.rst
@@ -20,6 +20,7 @@ Any of the :ref:`supported operations <x-supported-operations>` performed on an
 ``X`` object yield another one that remembers what was done to it, so they
 can be chained.
 
+.. _x-tilde
 The ``~`` operator creates the actual function that can be called (without
 creating just another ``X`` instance). However, this can be omitted within
 *pipe* and :doc:`pipeutils` context where ``X`` is converted to a function
@@ -43,26 +44,10 @@ remember to prefix it with ``~``
 Currently supported operations
 ------------------------------
 
-These are added as I need them. It's quite complete now, but if you're still
+Most Python operators are supported now, but if you're still
 missing something you can add it yourself or create an issue on github_.
 
 .. _github: https://github.com/0101/pipetools
-
-
-* call (``__call__``)::
-
-    X()
-    X(some, agrs, some=kwargs)
-
-
-* equals (``__eq__``)::
-
-    X == something
-
-
-* not equal (``__ne__``)::
-
-    X != something
 
 
 * attribute access (``__getattr__``)::
@@ -71,73 +56,81 @@ missing something you can add it yourself or create an issue on github_.
     getattr(X, 'something')
 
 
-* item access, slicing (``__getitem__``)::
+* comparisons: ``==``, ``!=``, ``<``, ``<=``, ``>``, ``>=``::
 
+    X == something
+    X <= 3
+
+
+* unary arithmetic operators (``+``, ``-``)::
+
+    +X
+    -X
+
+
+* binary arithmetic operators (``+``, ``-``, ``*``, ``**``, ``@``, ``/``, ``//``, ``%``)::
+
+    X - 3
+    X + " ...that's what she said!"
+    3 - X  # works in both directions
+
+
+* bitwise operators (``<<``, ``>>``, ``&``, ``^``)::
+
+    1 >> X
+    X & 64
+
+
+
+Current limitations
+-------------------
+
+* call (``__call__``) will only work if X is not in the arguments::
+
+    # will work
+    X.method()
+    X(some, agrs, some=kwargs)
+
+    # will not work
+    obj.method(X)
+    some_function(X, some=X)
+    X.do(X)
+
+
+* item access or slicing (``__getitem__``) will only work if X is not in the
+  in the index key::
+
+    # will work
     X['key']
     X[0]
     X[:10]
     X[::-1]
 
-
-* greater than (``__gt__``)::
-
-    X > 3
-
-
-* greater or equal (``__ge__``)::
-
-    X >= 3
+    # will not work
+    foo[X]
+    bar[X:]
+    baz[::X]
+    X[X.columns]
 
 
-* less than (``__lt__``)::
-
-    X < 3
-
-
-* less or equal (``__le__``)::
-
-    X <= 3
-
-
-* modulo (``__mod__``)::
-
-    X % 2
-
-
-* negate (``__neg__``)::
-
-    -X
-
-
-* multiplication (``__mul__``)::
-
-    X * 3
-
-
-* division (``__div__``)::
-
-    X / 3
-
-
-* addition (``__add__``)::
-
-    X + 3
-    X + " ...that's what she said!"
-
-
-* subtraction (``__sub__``)::
-
-    X - 3
-
-
-* power (``__pow__``)::
-
-    X ** 2
-
-
-* is contained in (``_in_``)
+* is contained in / contains (``in``)
 
   Unfortunately, ``X in container`` can't be done (because the magic method is
   called on the container) so there's a special method for that::
 
         X._in_(container)
+
+  The opposite form ``item in X`` has not been implemented either.
+
+
+* special methods (``~``, ``|``)
+
+  They have been given :ref:`special meanings <x-tilde>` in pipetools,
+  so could no more be used as bitwise operations.
+
+
+* logical operators (``and``, ``or``, ``not``) will not work;
+  they are not exposed as magic methods in Python.
+
+
+* await operator (``await X``) has not been implemented

--- a/pipetools/main.py
+++ b/pipetools/main.py
@@ -169,11 +169,11 @@ class XObject(object):
     def __le__(self, other):
         return self.bind(lambda: 'X <= {0!r}'.format(other), lambda x: x <= other)
 
-    def __mod__(self, y):
-        return self.bind(lambda: 'X % {0!r}'.format(y), lambda x: x % y)
-
     def __ne__(self, other):
         return self.bind(lambda: 'X != {0!r}'.format(other), lambda x: x != other)
+
+    def __pos__(self):
+        return self.bind(lambda: '+X', lambda x: +x)
 
     def __neg__(self):
         return self.bind(lambda: '-X', lambda x: -x)
@@ -181,23 +181,83 @@ class XObject(object):
     def __mul__(self, other):
         return self.bind(lambda: 'X * {0!r}'.format(other), lambda x: x * other)
 
-    def __floordiv__(self, other):
-        return self.bind(lambda: 'X / {0!r}'.format(other), lambda x: x // other)
+    def __rmul__(self, other):
+        return self.bind(lambda: '{0!r} * X'.format(other), lambda x: other * x)
+
+    def __matmul__(self, other):
+        # prevent syntax error on legacy interpretors
+        from operator import matmul
+        return self.bind(lambda: 'X @ {0!r}'.format(other), lambda x: matmul(x, other))
+
+    def __rmatmul__(self, other):
+        from operator import matmul
+        return self.bind(lambda: 'X @ {0!r}'.format(other), lambda x: matmul(other, x))
 
     def __div__(self, other):
         return self.bind(lambda: 'X / {0!r}'.format(other), lambda x: x / other)
 
+    def __rdiv__(self, other):
+        return self.bind(lambda: '{0!r} / X'.format(other), lambda x: other / x)
+
     def __truediv__(self, other):
         return self.bind(lambda: 'X / {0!r}'.format(other), lambda x: x / other)
+
+    def __rtruediv__(self, other):
+        return self.bind(lambda: '{0!r} / X'.format(other), lambda x: other / x)
+
+    def __floordiv__(self, other):
+        return self.bind(lambda: 'X // {0!r}'.format(other), lambda x: x // other)
+
+    def __rfloordiv__(self, other):
+        return self.bind(lambda: '{0!r} // X'.format(other), lambda x: other // x)
+
+    def __mod__(self, other):
+        return self.bind(lambda: 'X % {0!r}'.format(other), lambda x: x % other)
+
+    def __rmod__(self, other):
+        return self.bind(lambda: '{0!r} % X'.format(other), lambda x: other % x)
 
     def __add__(self, other):
         return self.bind(lambda: 'X + {0!r}'.format(other), lambda x: x + other)
 
+    def __radd__(self, other):
+        return self.bind(lambda: '{0!r} + X'.format(other), lambda x: other + x)
+
     def __sub__(self, other):
         return self.bind(lambda: 'X - {0!r}'.format(other), lambda x: x - other)
 
+    def __rsub__(self, other):
+        return self.bind(lambda: '{0!r} - X'.format(other), lambda x: other - x)
+
     def __pow__(self, other):
         return self.bind(lambda: 'X ** {0!r}'.format(other), lambda x: x ** other)
+
+    def __rpow__(self, other):
+        return self.bind(lambda: '{0!r} ** X'.format(other), lambda x: other ** x)
+
+    def __lshift__(self, other):
+        return self.bind(lambda: 'X << {0!r}'.format(other), lambda x: x << other)
+
+    def __rlshift__(self, other):
+        return self.bind(lambda: '{0!r} << X'.format(other), lambda x: other << x)
+
+    def __rshift__(self, other):
+        return self.bind(lambda: 'X >> {0!r}'.format(other), lambda x: x >> other)
+
+    def __rrshift__(self, other):
+        return self.bind(lambda: '{0!r} >> X'.format(other), lambda x: other >> x)
+
+    def __and__(self, other):
+        return self.bind(lambda: 'X & {0!r}'.format(other), lambda x: x & other)
+
+    def __rand__(self, other):
+        return self.bind(lambda: '{0!r} & X'.format(other), lambda x: other & x)
+
+    def __xor__(self, other):
+        return self.bind(lambda: 'X ^ {0!r}'.format(other), lambda x: x ^ other)
+
+    def __rxor__(self, other):
+        return self.bind(lambda: '{0!r} ^ X'.format(other), lambda x: other ^ x)
 
     def __ror__(self, func):
         return pipe | func | self

--- a/test_pipetools/test_main.py
+++ b/test_pipetools/test_main.py
@@ -80,36 +80,51 @@ class TestX:
     def test_mod(self):
 
         f = ~(X % 2)
+        g = ~(9 % X)
 
         assert f(3)
+        assert not g(3)
+        assert g(2)
         assert not f(2)
 
     def test_gt(self):
 
         f = ~(X > 5)
+        g = ~(6 > X)
 
         assert f(6)
+        assert not g(6)
+        assert g(5)
         assert not f(5)
 
     def test_gte(self):
 
         f = ~(X >= 5)
+        g = ~(4 >= X)
 
         assert f(5)
+        assert not g(5)
+        assert g(4)
         assert not f(4)
 
     def test_lt(self):
 
         f = ~(X < 5)
+        g = ~(4 < X)
 
         assert f(4)
+        assert not g(4)
+        assert g(5)
         assert not f(5)
 
     def test_lte(self):
 
         f = ~(X <= 5)
+        g = ~(6 <= X)
 
         assert f(5)
+        assert not g(5)
+        assert g(6)
         assert not f(6)
 
     def test_chained_gt(self):
@@ -139,6 +154,12 @@ class TestX:
         assert not f(42)
         assert f('whatever')
 
+    def test_pos(self):
+
+        f = ~+X
+
+        assert f(4) == 4
+
     def test_neg(self):
 
         f = ~-X
@@ -166,23 +187,51 @@ class TestX:
     def test_mul(self):
 
         f = ~(X * 3)
+        g = ~(3 * X)
 
-        assert f(10) == 30
-        assert f('x') == 'xxx'
+        assert f(10) == g(10) == 30
+        assert f('x') == g('x') == 'xxx'
 
     def test_add(self):
         assert (~(X + 2))(40) == 42
-        assert (~(X + '2'))('4') == '42'
-        assert (~(X + [2]))([4]) == [4, 2]
+        assert (~('4' + X))('2') == '42'
+        assert (~([4] + X))([2]) == [4, 2]
 
     def test_sub(self):
         assert (~(X - 3))(5) == (5 - 3)
+        assert (~(5 - X))(3) == (5 - 3)
 
     def test_pow(self):
         assert (~(X ** 3))(5) == (5 ** 3)
+        assert (~(5 ** X))(3) == (5 ** 3)
 
     def test_div(self):
         assert (~(X / 2))(4) == 2
+        assert (~(4 / X))(2) == 2
+
+    def test_floor_dev(self):
+        assert (~(X // 2))(5) == 2
+        assert (~(5 // X))(2) == 2
+
+    def test_mod(self):
+        assert (~(X % 5))('%.2f') == '5.00'
+        assert (~(5 % X))(2) == 1
+
+    def test_lshift(self):
+        assert (~(X << 2))(5) == 20
+        assert (~(2 << X))(5) == 64
+
+    def test_rshift(self):
+        assert (~(X >> 1))(5) == 2
+        assert (~(5 >> X))(1) == 2
+
+    def test_xor(self):
+        assert (~(X ^ 2))(3) == 1
+        assert (~(1 ^ X))(3) == 2
+
+    def test_and(self):
+        assert (~(X & 2))(3) == 2
+        assert (~(1 & X))(3) == 1
 
     def test_in(self):
         container = 'asdf'


### PR DESCRIPTION
This patch added support for:

```py
2 ** (64 - X)   # __rpow__, __rsub__, and all other __rFOOBAR__ methods
X >> 8          # __rshift__ and __rrshift__ (There were already X > 8 and X < 8, so I guess X >> 8 does not indicate a pipe redirection either)
1 << (64 - X)   # __lshift__ and __rlshift__
X @ np.eye(10)  # matrix multiplication since Python 3.5
X & 1
X ^ 1
+X              # I wonder if anyone would ever use this unary operator...
```

This patch also fixed a tiny repr problem:
```py
>>> X // 42
X / 42          # should have been X // 42, even in Python 2.7
```

This patch did not add support for:
```py
index in X      # the opposite of X._in_(index); __contains__ did not work and always returned True?
len(X)          # it would be confusing and inconsistent if built-in functions worked, but custom functions did not...
```

Magic method references: [Python 2](https://docs.python.org/2/reference/datamodel.html#special-method-names), [Python 3](https://docs.python.org/3/reference/datamodel.html#special-method-names)